### PR TITLE
Add closure notice banner and simplify navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import './App.css';
+import ClosureBanner from './components/ClosureBanner';
 import Header from './components/Header';
 import HeroSection from './sections/HeroSection';
 import WelcomeSection from './sections/WelcomeSection';
@@ -77,6 +78,7 @@ function App() {
 
   return (
     <div className="min-h-screen bg-white">
+      <ClosureBanner />
       <Header currentPage={currentPage} onPageChange={handlePageChange} />
       
       <main>

--- a/src/components/ClosureBanner.tsx
+++ b/src/components/ClosureBanner.tsx
@@ -1,0 +1,44 @@
+import { AlertCircle, Github } from 'lucide-react';
+
+export default function ClosureBanner() {
+  return (
+    <div
+      className="w-full"
+      style={{ backgroundColor: 'var(--scapa-red)' }}
+    >
+      <div className="container-scapa py-4 px-4">
+        <div className="flex flex-col md:flex-row items-start md:items-center gap-3">
+          <AlertCircle className="text-white shrink-0" size={24} />
+          <div className="flex-1">
+            <p className="text-white font-semibold text-sm md:text-base">
+              Scapa Technologies Limited has ceased trading and is in the process of being dissolved.
+            </p>
+            <div className="flex flex-wrap items-center gap-2 mt-2">
+              <span className="text-white/90 text-sm">The Scapa software is now open source and available at</span>
+              <a
+                href="https://github.com/scapatech"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1.5 text-white font-medium underline hover:no-underline transition-opacity hover:opacity-90 text-sm"
+              >
+                <Github size={16} />
+                github.com/scapatech
+              </a>
+            </div>
+            <p className="text-white/90 text-sm mt-2">
+              For software enquiries, please open an issue at{' '}
+              <a
+                href="https://github.com/scapatech/stpp/issues"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline hover:no-underline transition-opacity hover:opacity-90 font-medium"
+              >
+                github.com/scapatech/stpp/issues
+              </a>
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -21,9 +21,7 @@ export default function Header({ currentPage, onPageChange }: HeaderProps) {
 
   const navItems = [
     { id: 'solutions', label: 'Solutions' },
-    { id: 'services', label: 'Services' },
     { id: 'success', label: 'Success' },
-    { id: 'contact', label: 'Contact Us' },
   ];
 
   const handleNavClick = (pageId: string) => {
@@ -41,22 +39,14 @@ export default function Header({ currentPage, onPageChange }: HeaderProps) {
         }`}
         style={{ backgroundColor: 'var(--scapa-blue)' }}
       >
-        <div className="container-scapa h-full flex items-center justify-between section-padding">
-          <p 
-            className={`text-white text-xs transition-all duration-300 hidden sm:block ${
+        <div className="container-scapa h-full flex items-center section-padding">
+          <p
+            className={`text-white text-xs transition-all duration-300 ${
               isScrolled ? 'opacity-0' : 'opacity-100'
             }`}
           >
             The end to end infrastructure and application delivery performance specialists
           </p>
-          <div className="flex items-center gap-4 ml-auto">
-            <button
-              onClick={() => handleNavClick('contact')}
-              className="btn-primary text-xs py-1.5 px-4"
-            >
-              REQUEST A DEMO
-            </button>
-          </div>
         </div>
       </div>
 


### PR DESCRIPTION
## Changes

- Add prominent closure banner announcing company cessation
- Note software is now open source at github.com/scapatech  
- Link to GitHub issues for enquiries
- Remove Services and Contact from navigation
- Remove Request a Demo button

## Preview

The banner appears at the very top of the site with:
- Red background for visibility
- Clear message about company closure
- Links to GitHub for the open source software and issue tracker